### PR TITLE
Adjust embedded images on playbook to fit screen width

### DIFF
--- a/src/assets/style-dark.css
+++ b/src/assets/style-dark.css
@@ -696,6 +696,9 @@ img.logo {
     width: 100%;
 }
 
+.dailyCard img {
+    width: 100%;
+}
 
 .cardFirstLine {
     border-bottom: 1px solid lightgray;


### PR DESCRIPTION
Prevents large images embedded in a playbook entry from overflowing the screen width.

From this:
<img width="1470" alt="Screenshot 2023-08-25 at 12 20 43" src="https://github.com/Eleven-Trading/TradeNote/assets/2751266/c0d6b289-78a4-47c7-9dac-33e7b88b134e">

To this:
<img width="1468" alt="Screenshot 2023-08-25 at 12 21 25" src="https://github.com/Eleven-Trading/TradeNote/assets/2751266/59b9b52c-d974-4ff5-bba3-4ca4dff8b2b7">
